### PR TITLE
Fixing ref length percent in FASTA header and comments

### DIFF
--- a/bin/get_final_sequences.py
+++ b/bin/get_final_sequences.py
@@ -16,9 +16,8 @@ of reference sequence that aligned with assembled sequence.
         5. Path to ea_map.tsv output from extract_alleles.py
         6. Name of an outfile to populate with the final assemblies
         7. Path to where the unbuffered FASTA from extract_sequences.py is 
-        8. Optional minimum length ratio of an assembled sequence that should
-           be aligned to. For instance, enter 0.5 to not align constructed 
-           sequences less than 50% of the original sequence length. Default 0.5.
+        8. Optional minimum length ratio of an assembled sequence as cutoff 
+           for pulling a sequence or not. Default 0.5.
 
     Output:
         1. An outfile containing all the best assembled sequences 
@@ -46,7 +45,7 @@ def main():
     parser.add_argument('--outfile', '-o', type=str, required=True, help='Name of an outfile.')
     parser.add_argument('--ea_map', '-eam', type=str, required=True, help='Path to ea_map.tsv output from extract_alleles.py.')
     parser.add_argument('--original_fsa', '-of', type=str, required=True, help='Path to where the unbuffered FASTA from extract_sequences.py is.')
-    parser.add_argument('--min_align_len', '-minl', type=float, required=False, default=0.5, help='Optional minimum length ratio of an assembled sequence that should be aligned to. For instance, enter 0.5 to not align constructed sequences less than 50% of the original sequence length. Default 0.5.')
+    parser.add_argument('--min_align_len', '-minl', type=float, required=False, default=0.5, help='Optional minimum length ratio of an assembled sequence as cutoff for pulling a sequence or not. Default 0.5.')
     args = parser.parse_args()
 
     best_id,cds_map = (defaultdict(list) for i in range(2)) 

--- a/bin/threaded_assess_alignment.py
+++ b/bin/threaded_assess_alignment.py
@@ -97,7 +97,6 @@ def spades_worker(algn_dir,locus,priority,best_only,queue):
     # no alignments to have been performed. Print to STDOUT in case
     # this does happen. 
     aligned = False
-    a_align_seq = ''
     # Found the alignment directory for this locus, now iterate over 
     # the final alignments and pull the best score.
     for file in os.listdir(algn_dir):
@@ -124,6 +123,8 @@ def spades_worker(algn_dir,locus,priority,best_only,queue):
                 else:
                     b = str(sequence.seq)
                 
+                a_align_seq = a
+
                 # Finding the length of reference sequence in alignment
                 if a != "" and b!= "":
                     if a[0] != "-" and b[0] == "-":
@@ -221,7 +222,6 @@ def scaffold_worker(algn_dir,locus,priority,best_only,queue):
     # no alignments to have been performed. Print to STDOUT in case
     # this does happen. 
     aligned = False
-    a_align_seq = ''
     # Found the alignment directory for this locus, now iterate over 
     # the final alignments and pull the best score.
     for file in os.listdir(algn_dir):
@@ -253,7 +253,8 @@ def scaffold_worker(algn_dir,locus,priority,best_only,queue):
                     a = str(sequence.seq)
                 else:
                     b = str(sequence.seq)
-                
+               
+                a_align_seq = a                
 
              # Finding the length of reference sequence in alignment
                 if a != "" and b!= "":

--- a/cwl/get_final_sequences.cwl
+++ b/cwl/get_final_sequences.cwl
@@ -56,7 +56,7 @@ inputs:
       prefix: "--outfile"
 
   min_align_len:
-    label: Minimum alignment length to perform alignment with (RATIO)
+    label: Minimum alignment length ratio of assembled sequence as cutoff to pull sequence or not
     type: double
     inputBinding:
       prefix: "--min_align_len"
@@ -71,6 +71,5 @@ outputs:
     type: File
     outputBinding:
       glob: $(inputs.outfile)
-
 
 baseCommand: ["PYTHON3_EXE","TARGETED_ASSEMBLY_BIN/get_final_sequences.py"]

--- a/cwl/phase_three.cwl
+++ b/cwl/phase_three.cwl
@@ -74,7 +74,7 @@ inputs:
     type: int
 
   min_align_len:
-    label: Minimum alignment length to perform alignment with (RATIO)
+    label: Minimum alignment length ratio of assembled sequence as cutoff to pull sequence or not
     type: double
 
   assmb_stdout:

--- a/cwl/targeted_assembly.cwl
+++ b/cwl/targeted_assembly.cwl
@@ -174,7 +174,7 @@ inputs:
     type: int
 
   min_align_len:
-    label: Minimum alignment length to perform alignment with (RATIO)
+    label: Minimum alignment length ratio of assembled sequence as cutoff to pull sequence or not
     type: double
 
 

--- a/cwl/targeted_assembly.yml
+++ b/cwl/targeted_assembly.yml
@@ -91,7 +91,7 @@ kmer: 7,11,21
 # than the read length. Max 100.
 recruitment_threshold: 50
 # The ratio for how long an assembled sequence must be compared to the reference
-# in order to even attempt alignment. Max 1.0
+# to be reported in the final assembled sequences file. Max 1.0
 min_align_len: 0.5
 # Cutoff for considering a sequence to be assembled or not. Max 100. 
 aligner_threshold: 90


### PR DESCRIPTION
Fixed reference length percentage output in FASTA headers of final output files. Fixed comments for min_align_len description.