### PR TITLE
Fixing input gene id extraction for unbuffered ref seq length calculation

### DIFF
--- a/bin/extract_reconstructions.py
+++ b/bin/extract_reconstructions.py
@@ -68,11 +68,11 @@ def main():
     for k in best_len:
         path = best_len[k][5]
         path_list = path.split('/')
+        ref_seq = path_list[-1].split('.WITH')[0]
         new_id = "assembled_{0}".format(k)
         file_ = path.replace('trimmed_align.txt', 'b.fsa')
         
         ref_len = int(best_len[k][4])
-        ref_seq = "{0}.{1}".format(best_len[k][3], path_list[-2])
         seq = seq_dict[ref_seq]
         ref_len_percent = round((ref_len/len(seq)*100), 2)
 

--- a/bin/get_final_sequences.py
+++ b/bin/get_final_sequences.py
@@ -61,8 +61,11 @@ def main():
             entity = ""
             if args.groupby != 'l':
                 entity = os.path.basename(elements[5]).split('.WITH')[0]
+                #Check ids_v_cov.tsv to find ref.geneID; test the following line
+                #ref_seq = entity
             else:
                 entity = os.path.basename(elements[5]).split('.')[1]
+                ref_seq = os.path.basename(elements[5]).split('.WITH')[0]
 
             # Modify the path to where this file is found; needs some extra 
             # handholding to work both with/without CWL
@@ -70,8 +73,8 @@ def main():
             split_point = os.path.basename(base_dir)
             tmp_path = elements[5].split(split_point)[1]
             file_path = "{0}/{1}".format(base_dir,tmp_path)
-            ref_seq = "{0}.{1}".format(elements[3],entity)
             unbuffered_ref_seq = seq_dict[ref_seq]
+            
             # Sort the %ID into bins
             id = 0.0
             if len(elements) == 6:


### PR DESCRIPTION
- Fixed input gene ID extraction method for finding headers of unbuffered reference sequence to calculate its length
- This covers cases such as gene IDs 'PF3D7_0206900.1'