### PR TITLE
Adding two secondary output files, minor fixes

### DIFF
--- a/bin/extract_reconstructions.py
+++ b/bin/extract_reconstructions.py
@@ -2,9 +2,10 @@
 
 '''
 This script follows threaded_assess_alignment.py and pulls the longest assembled sequence
-regardless of the threshold for each locus into a FASTA file. The FASTA header shall
-include the locus ID, %ID, length of the sequence assembled and proportion of reference 
-sequence length that aligned with assembled sequence.
+regardless of the threshold for each locus and the best %ID sequence for each locus into 
+a FASTA file. This script ignores repeated sequences by comparing with assembled_seqs.fsa
+file. The FASTA header shall include the locus ID, %ID, length of the sequence assembled and 
+proportion of reference sequence length that aligned with assembled sequence.
 
 This script runs after both the iterations are completed (after first and second_ids_v_cov.tsv generated)
 or after the first iteration in cases where second iteration with SMALT isn't necessary.
@@ -17,13 +18,15 @@ or after the first iteration in cases where second iteration with SMALT isn't ne
         5. Path to ids_v_cov.tsv file generated from threaded_assess_alignment.py after HGA+SB step in second iteration (first_final_phase_three)
         6. Path to ids_v_cov.tsv file generated from threaded_assess_alignment.py after SPAdes step in first iteration (first_intermediary_phase_three)
         7. Path to ids_v_cov.tsv file generated from threaded_assess_alignment.py after SPAdes step in second iteration (second_intermediary_phase_three)
-        8. Path to the unbuffered FASTA from extract_sequences.py
+        8. Path to assembled_seqs.fsa file generated from gather_sequences step 
+        9. Path to the unbuffered FASTA from extract_sequences.py
 
     Output:
-        An outfile assembled_seqs_below_threshold.fsa containing longest assembled sequences
+        1. A file secondary_seqs_by_length.fsa containing longest assembled sequences
+        2. Another file secondary_seqs_by_id.fsa containing best %id sequences
 
     Usage:
-        extract_reconstructions.py -fivc path/to/file -fap path/to/first_alignments -sap path/to/second_alignments -sivc path/to/file -fidvc path/to/file -sidvc path/to/file
+        extract_reconstructions.py -fivc path/to/file -fap path/to/first_alignments -sap path/to/second_alignments -sivc path/to/file -fidvc path/to/file -sidvc path/to/file -af path/to/assembled_seqs.fsa -of path/to/unbuffered/fasta/file
 
     Author:
         Chakshu Gandhi
@@ -44,10 +47,12 @@ def main():
     parser.add_argument('--second_ids_v_cov', '-sivc', type=str, help='Path to .tsv file generated from threaded_assess_alignment.py in second iteration after HGA+SB step')
     parser.add_argument('--first_idvc', '-fidvc', type=str,  help='Path to .tsv file generated from threaded_assess_alignment.py in first iteration after SPAdes step')
     parser.add_argument('--second_idvc', '-sidvc', type=str, help='Path to .tsv file generated from threaded_assess_alignment.py in second iteration after SPAdes step')
+    parser.add_argument('--assmb_file', '-af', type=str, help='Path to assembled_seqs.fsa file generated from gather_sequences step')
     parser.add_argument('--original_fsa', '-of', type=str, required=True, help='Path to where the unbuffered FASTA from extract_sequences.py is.')
     args = parser.parse_args()
     
-    sequences_list = []
+    best_len_seq_list = []
+    best_id_seq_list = []
     first_ivc = args.first_ids_v_cov
     second_ivc = args.second_ids_v_cov
     first_idvc = args.first_idvc
@@ -55,16 +60,24 @@ def main():
     first_ap = args.first_align_path
     second_ap = args.second_align_path
     best_len = defaultdict(list)
+    best_id = defaultdict(list)
+    primary_seqs = defaultdict(list)
+    assmb_file = args.assmb_file
     seq_dict = SeqIO.to_dict(SeqIO.parse(args.original_fsa,"fasta"))
-    outfile = "{0}/assembled_seqs_below_threshold.fsa".format(args.workspace_location)
+    outfile = "{0}/secondary_seqs_by_length.fsa".format(args.workspace_location)
+    outfile2 = "{0}/secondary_seqs_by_id.fsa".format(args.workspace_location)
+    primary_seqs = primary_output_to_dict(assmb_file,primary_seqs)
+    best_len = extract_length_list(first_idvc, best_len, first_ap, second_ap, primary_seqs)
+    best_len = extract_length_list(first_ivc, best_len, first_ap, second_ap, primary_seqs)
+    best_len = extract_length_list(second_idvc, best_len, first_ap, second_ap, primary_seqs)
+    best_len = extract_length_list(second_ivc, best_len, first_ap, second_ap, primary_seqs)
+    best_id = extract_id_list(first_idvc, best_id, first_ap, second_ap, primary_seqs)
+    best_id = extract_id_list(first_ivc, best_id, first_ap, second_ap, primary_seqs)
+    best_id = extract_id_list(second_idvc, best_id, first_ap, second_ap, primary_seqs)
+    best_id = extract_id_list(second_ivc, best_id, first_ap, second_ap, primary_seqs)
 
-    best_len = extract_list(first_idvc, best_len, first_ap, second_ap)
-    best_len = extract_list(first_ivc, best_len, first_ap, second_ap)
-    best_len = extract_list(second_idvc, best_len, first_ap, second_ap)
-    best_len = extract_list(second_ivc, best_len, first_ap, second_ap)
     
-    
-    # Pulling FASTA sequences together, editing headers for FASTA records
+    # Pulling FASTA sequences with best length together, editing headers for FASTA records
     for k in best_len:
         path = best_len[k][5]
         path_list = path.split('/')
@@ -83,13 +96,37 @@ def main():
         if '.r.trimmed' in path:
             rev_seq = Seq(str(record.seq))
             record.seq = rev_seq.reverse_complement()
-        sequences_list.append(record)
+        best_len_seq_list.append(record)
 
-    SeqIO.write(sequences_list, outfile, 'fasta')
+    SeqIO.write(best_len_seq_list, outfile, 'fasta')
+
+    # Pulling FASTA sequences with best id together, editing headers for FASTA records
+    for k in best_id:
+        path = best_id[k][5]
+        path_list = path.split('/')
+        ref_seq = path_list[-1].split('.WITH')[0]
+        new_id = "assembled_{0}".format(k)
+        file_ = path.replace('trimmed_align.txt', 'b.fsa')
+
+        ref_len = int(best_id[k][4])
+        seq = seq_dict[ref_seq]
+        ref_len_percent = round((ref_len/len(seq)*100), 2)
+
+        record = SeqIO.read(file_,"fasta")
+        record.id = new_id
+        record.description = 'ID_to_ref={0} len={1} ref_len_percent={2}'.format(str(best_id[k][0]),str(best_id[k][2]),str(ref_len_percent))
+        record.name = ''
+        if '.r.trimmed' in path:
+            rev_seq = Seq(str(record.seq))
+            record.seq = rev_seq.reverse_complement()
+        
+        best_id_seq_list.append(record)
+
+    SeqIO.write(best_id_seq_list, outfile2, 'fasta')    
 
 # Parses through each ids_v_cov.tsv (first and second) and stores the longest assembled
 # sequence details in best_len dictionary 
-def extract_list(infile, best_len, first_ap, second_ap):
+def extract_length_list(infile, best_len, first_ap, second_ap, primary_seqs):
   if os.path.exists(infile):
     with open(infile, 'r') as f1:
         for line in f1:
@@ -111,10 +148,18 @@ def extract_list(infile, best_len, first_ap, second_ap):
                 tmp_path = ivc_list[5].split(second_split_point)[1]
                 file_path = "{0}/{1}".format(second_ap,tmp_path)
             ivc_list[5] = file_path
-                
+
+
+            # Ensuring sequences from assembled_seqs.fsa are not repeated
+            if primary_seqs[locus]:
+                # check length id
+                if (length == primary_seqs[locus][1]) and ((len(ivc_list)==6 and float(ivc_list[0])==primary_seqs[locus][0]) or (len(ivc_list) != 6 and float(ivc_list[6])==primary_seqs[locus][0])):
+                        continue
+
+
            # Updating best_len dictionary with longest sequence details for each locus     
             if locus in best_len:
-                if length > int(best_len[locus][2]) and len(ivc_list) == 6:
+                if length > int(best_len[locus][2]) and len(ivc_list) == 6 :
                     best_len[locus][0] = float(ivc_list[0])
                     best_len[locus][1] = float(ivc_list[1])
                     best_len[locus][2] = int(ivc_list[2])
@@ -163,5 +208,104 @@ def extract_list(infile, best_len, first_ap, second_ap):
                     best_len[locus].append(ivc_list[5])
 
     return best_len
+
+# Parses through each ids_v_cov.tsv (first and second) and stores the best id
+# sequence details in best_id dictionary 
+def extract_id_list(infile, best_id, first_ap, second_ap, primary_seqs):
+  if os.path.exists(infile):
+    with open(infile, 'r') as f1:
+        for line in f1:
+            line = line.rstrip()
+            ivc_list = line.split()
+            aligned = ivc_list[5].split('.WITH.')[1]
+            locus = ivc_list[5].split('.')[1]
+            prcnt_id = float(ivc_list[0]) if len(ivc_list)==6 else float(ivc_list[6])
+            align_dir = ivc_list[5].split('/')[-3]
+
+           # Checks if the ids_v_cov.tsv file has paths from first/second_alignments directory
+           # and accordingly chooses the align_path to extract sequences
+            first_split_point = os.path.basename(first_ap)
+            second_split_point = os.path.basename(second_ap)
+            if align_dir == first_split_point:
+                tmp_path = ivc_list[5].split(first_split_point)[1]
+                file_path = "{0}/{1}".format(first_ap,tmp_path)
+            elif align_dir == second_split_point:
+                tmp_path = ivc_list[5].split(second_split_point)[1]
+                file_path = "{0}/{1}".format(second_ap,tmp_path)
+            ivc_list[5] = file_path
+
+
+            # Ensuring sequences from assembled_seqs.fsa are not repeated
+            if primary_seqs[locus]:
+                # check length and id
+                if (int(ivc_list[2]) == primary_seqs[locus][1]) and ((len(ivc_list)==6 and float(ivc_list[0])==primary_seqs[locus][0]) or (len(ivc_list) != 6 and float(ivc_list[6])==primary_seqs[locus][0])):
+                        continue
+
+
+           # Updating best_id dictionary with best percent id sequence details for each locus     
+            if locus in best_id:
+                if prcnt_id > float(best_id[locus][0]) and len(ivc_list) == 6 :
+                    best_id[locus][0] = float(ivc_list[0])
+                    best_id[locus][1] = float(ivc_list[1])
+                    best_id[locus][2] = int(ivc_list[2])
+                    best_id[locus][3] = ivc_list[3]
+                    best_id[locus][4] = int(ivc_list[4])
+                    best_id[locus][5] = ivc_list[5]
+                elif prcnt_id > float(best_id[locus][0]) and len(ivc_list) != 6:
+                    best_id[locus][0] = float(ivc_list[6])
+                    best_id[locus][1] = float(ivc_list[1])
+                    best_id[locus][2] = int(ivc_list[2])
+                    best_id[locus][3] = ivc_list[3]
+                    best_id[locus][4] = int(ivc_list[4])
+                    best_id[locus][5] = ivc_list[5]
+                elif prcnt_id == int(best_id[locus][0]) and len(ivc_list) == 6:
+                    if float(ivc_list[0]) > best_id[locus][0]:
+                        best_id[locus][0] = float(ivc_list[0])
+                        best_id[locus][1] = float(ivc_list[1])
+                        best_id[locus][2] = int(ivc_list[2])
+                        best_id[locus][3] = ivc_list[3]
+                        best_id[locus][4] = int(ivc_list[4])
+                        best_id[locus][5] = ivc_list[5]
+                elif prcnt_id == int(best_id[locus][0]) and len(ivc_list) != 6:
+                    if float(ivc_list[6]) > best_id[locus][0]:
+                        best_id[locus][0] = float(ivc_list[0])
+                        best_id[locus][1] = float(ivc_list[1])
+                        best_id[locus][2] = int(ivc_list[2])
+                        best_id[locus][3] = ivc_list[3]
+                        best_id[locus][4] = int(ivc_list[4])
+                        best_id[locus][5] = ivc_list[5]
+                else:
+                    continue
+            else:
+                if len(ivc_list) == 6:
+                    best_id[locus].append(float(ivc_list[0]))
+                    best_id[locus].append(float(ivc_list[1]))
+                    best_id[locus].append(int(ivc_list[2]))
+                    best_id[locus].append(ivc_list[3])
+                    best_id[locus].append(int(ivc_list[4]))
+                    best_id[locus].append(ivc_list[5])
+                else:
+                    best_id[locus].append(float(ivc_list[6]))
+                    best_id[locus].append(float(ivc_list[1]))
+                    best_id[locus].append(int(ivc_list[2]))
+                    best_id[locus].append(ivc_list[3])
+                    best_id[locus].append(int(ivc_list[4]))
+                    best_id[locus].append(ivc_list[5])
+
+    return best_id
+
+# Stores the percent id and sequence length details from assembled_seqs.fsa
+# in a dictionary for easy comparison
+def primary_output_to_dict(assmb_file,primary_seqs):
+    record_id_regex = r"[>a-zA-Z]*[_]([a-zA-Z0-9]*[_][0-9]*)"
+    prcnt_id_regex = r"[A-Z]+[_][a-z]+[_][a-z]+[=]([0-9.]*)"
+    record_len_regex = r"[0-9.]*\s[a-z]+[=]([0-9]+)"
+    for record in SeqIO.parse(assmb_file,'fasta'):
+        record_id = re.search(record_id_regex,record.id).group(1)
+        prcnt_id = re.search(prcnt_id_regex,record.description).group(1)
+        record_len = re.search(record_len_regex,record.description).group(1)
+        primary_seqs[record_id].append(float(prcnt_id))
+        primary_seqs[record_id].append(int(record_len))
+    return primary_seqs
 
 main()

--- a/bin/fastq_reads_to_fastq_alleles.py
+++ b/bin/fastq_reads_to_fastq_alleles.py
@@ -37,7 +37,7 @@ refine the FASTQ output if the filter option is used.
         James Matsumura
 """
 
-import argparse,gzip,itertools
+import argparse,gzip,itertools,os,sys
 from collections import defaultdict
 from shared_fxns import make_directory
 
@@ -181,6 +181,12 @@ def main():
     # need to filter all the FASTQ reads to just those that aligned to a gene region.
     filter_fastq(ids_to_keep,args.fastq1,args.fastq2,output)
 
+    # Exiting program if reads.fastq.gz file is not created
+    for ref in unique_refs:
+        path = "{0}/{1}/reads.fastq.gz".format(output,ref)
+        if os.path.exists(path) == False:
+            print("File reads.fastq does not exist. Check paired_suffixes parameter for possible error.")
+            sys.exit(1)
 
 # Function to compare where the two mates in a pair mapped to. Returns 
 # 'single_map' if both only map to a single locus, 'multi_map' if one

--- a/bin/fastq_reads_to_fastq_alleles.py
+++ b/bin/fastq_reads_to_fastq_alleles.py
@@ -183,8 +183,9 @@ def main():
 
     # Exiting program if reads.fastq.gz file is not created
     for ref in unique_refs:
-        path = "{0}/{1}/reads.fastq.gz".format(output,ref)
-        if os.path.exists(path) == False:
+        path1 = "{0}/{1}/reads.fastq.gz".format(output,ref)
+        path2 = "{0}/{1}/reads.fastq".format(output,ref)
+        if os.path.exists(path1) == False or os.path.exists(path2) == False:
             print("File reads.fastq does not exist. Check paired_suffixes parameter for possible error.")
             sys.exit(1)
 

--- a/bin/threaded_alignment.py
+++ b/bin/threaded_alignment.py
@@ -167,7 +167,10 @@ def worker(locus,contigs,ref_list,seq_dict,out_dir,max_len,queue,assmb_type,prio
             sequence = str(record.seq)
             record.seq = Seq(sequence.replace("N",""))
         record_len.append(int(len(record)))
-    max_len_record = max(record_len)
+    record_len.sort()
+    third_from_max = record_len[-3]
+    second_from_max = record_len[-2]
+    max_len_record = record_len[-1]
 
     # Iterate over each contig assembled
     for record in SeqIO.parse(contigs,"fasta"):
@@ -212,8 +215,8 @@ def worker(locus,contigs,ref_list,seq_dict,out_dir,max_len,queue,assmb_type,prio
 
             seq = seq_dict[ref_seq]
 
-            # Letting the longest assembled sequence pass the length filter
-            if len(record) == max_len_record:
+            # Letting three longest assembled sequences pass the length filter
+            if len(record) == max_len_record or len(record) == second_from_max or len(record) == third_from_max:
                pass
 
             # Some of the shorter assembled sequences hold little to no 

--- a/bin/threaded_assess_alignment.py
+++ b/bin/threaded_assess_alignment.py
@@ -123,15 +123,11 @@ def spades_worker(algn_dir,locus,priority,best_only,queue):
                 else:
                     b = str(sequence.seq)
                 
-                a_align_seq = a
 
-                if a != "" and b!= "":
-                    ref_align_len = find_ref_len(a,b,a_align_seq)
-
-
-                if a != "" and b != "":
-                    a = a.replace('-','')
-                    b = b.replace('-','')
+            if a != "" and b!= "":
+                ref_align_len = find_ref_len(a,b)
+                a = a.replace('-','')
+                b = b.replace('-','')
 
             stats = parse_alignment(full_path)
 
@@ -242,12 +238,9 @@ def scaffold_worker(algn_dir,locus,priority,best_only,queue):
                 else:
                     b = str(sequence.seq)
                
-                a_align_seq = a
 
                 if a != "" and b!= "":
-                    ref_align_len = find_ref_len(a,b,a_align_seq)
-
-                if a != "" and b != "":
+                    ref_align_len = find_ref_len(a,b)
                     # Check how many bases of A are covered by B with exact 
                     # matches and output this percentage. Ignore gaps.
                     nogap_id.append(calculate_exact_alignment(a,b)) 
@@ -376,7 +369,8 @@ def calculate_exact_alignment(aseq,bseq):
 
 
 # Finding the length of reference sequence in alignment
-def find_ref_len(a,b,a_align_seq):
+def find_ref_len(a,b):
+    a_align_seq = a
     if a[0] != "-" and b[0] == "-":
         bstrip1 = b.lstrip('-')
         ltrim = len(b) - len(bstrip1)

--- a/cwl/extract_reconstructions.cwl
+++ b/cwl/extract_reconstructions.cwl
@@ -1,13 +1,13 @@
 #!/usr/bin/env cwl-runner
 cwlVersion: v1.0
-label: Targeted Assembly -- pull sequences reconstructed below threshold
+label: Targeted Assembly -- pull secondary reconstructed sequences
 class: CommandLineTool
 
 requirements:
   - class: InlineJavascriptRequirement
   - class: EnvVarRequirement
     envDef:
-      - envName: LD_LIBRARY_PATH
+        envName: LD_LIBRARY_PATH
         envValue: $(inputs.python3_lib)
 
 inputs:
@@ -58,6 +58,12 @@ inputs:
     inputBinding:
       prefix: "--second_idvc"
 
+  assembled_seqs:
+    label: Path to assembled_seqs.fsa file generated from gather_sequences step
+    type: File
+    inputBinding:
+      prefix: "--assmb_file"
+
   original_fsa:
     label: Path to where the unbuffered FASTA file generated from extract_sequences is
     type: File
@@ -65,9 +71,14 @@ inputs:
       prefix: "--original_fsa"
 
 outputs:
-  assembled_below_threshold:
+  assembled_by_length:
     type: File
     outputBinding:
-      glob: $(inputs.workspace_location + '/assembled_seqs_below_threshold.fsa')
+      glob: $(inputs.workspace_location + '/secondary_seqs_by_length.fsa')
 
-baseCommand: ["PYTHON3_EXE","TARGETED_ASSEMBLY_BIN/extract_reconstructions.py"]
+  assembled_by_id:
+    type: File
+    outputBinding:
+      glob: $(inputs.workspace_location + '/secondary_seqs_by_id.fsa')
+
+baseCommand: [PYTHON3_EXE, TARGETED_ASSEMBLY_BIN+"/extract_reconstructions.py"]

--- a/cwl/targeted_assembly.cwl
+++ b/cwl/targeted_assembly.cwl
@@ -277,9 +277,13 @@ outputs:
     type: File
     outputSource: gather_sequences/all_seqs
 
-  assembled_below_threshold:
+  assembled_by_length:
     type: File
-    outputSource: extract_reconstructions_step/assembled_below_threshold
+    outputSource: extract_reconstructions_step/assembled_by_length
+
+  assembled_by_id:
+    type: File
+    outputSource: extract_reconstructions_step/assembled_by_id
 
 steps:
   phase_one:
@@ -632,6 +636,8 @@ steps:
       second_idvc : second_intermediary_phase_three/ids_v_cov
       second_ids_v_cov : second_final_phase_three/ids_v_cov
       original_fsa: phase_one/unbuffered_sequences
+      assembled_seqs: gather_sequences/all_seqs
     out: [
-      assembled_below_threshold
+      assembled_by_length,
+      assembled_by_id
     ]


### PR DESCRIPTION
- Keeping a check when the pipeline does not produce reads.fastq files, pipeline exits
- Minor modular changes to existing code
- Outputting two secondary files, by longest assembled sequence and by best %id possible. This also ensures reconstructions in secondary files are not repeated with the primary file assembled_seqs.fsa.